### PR TITLE
Add support for optional PATH_PREFIX environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Configuration
 - `AWS_SECRET_KEY` - secret access key. Mandatory.
 - `AWS_REGION` - AWS region name for configured SNS (i.e., `eu-west-1`). Mandatory.
 - `AUTOSUBSCRIBE_TOPICS` - optional. Comma-separated list of topics each device will be subscribed automatically during registration.
+- `PATH_PREFIX` - optional. A prefix added to the URL path (without the leading `/`). eg. with a value of `push-service` the `topics` endpoint would be under `/push-service/topics`
 
 Configuring platform applications: create platform applications in SNS first. In this service, you need to invent aliases for each platform application. For example, if you have platform application with identifier `arn:aws:sns:eu-west-1:133752156591:app/WNS/your-app-name-here`, you can add environment variable
 

--- a/push_service/app.py
+++ b/push_service/app.py
@@ -323,22 +323,28 @@ class PublishMessage(Resource):
         target_id = decode_base64_id(target_id)
         return publish(data, target_id)
 
+# Check for path prefix
+if os.environ.get('PATH_PREFIX'):
+    PATH_PREFIX = "/" + os.environ.get('PATH_PREFIX')
+    logger.info("PATH_PREFIX set to '%s'", PATH_PREFIX)
+else:
+    PATH_PREFIX = ""
 
-api.add_resource(Device, "/device")
-api.add_resource(DeviceDetails, "/device/<endpoint_id>")
-api.add_resource(Topics, "/topics")  # POST is admin-only operation.
-api.add_resource(Subscription, "/subscription/topic/<topic_id>/target/<target_id>")
+api.add_resource(Device, PATH_PREFIX + "/device")
+api.add_resource(DeviceDetails, PATH_PREFIX + "/device/<endpoint_id>")
+api.add_resource(Topics, PATH_PREFIX + "/topics")  # POST is admin-only operation.
+api.add_resource(Subscription, PATH_PREFIX + "/subscription/topic/<topic_id>/target/<target_id>")
 
-api.add_resource(Status, "/status")
-api.add_resource(UrlList, "/", resource_class_kwargs={"api": api})
+api.add_resource(Status, PATH_PREFIX + "/status")
+api.add_resource(UrlList, PATH_PREFIX + "/", resource_class_kwargs={"api": api})
 
 # admin endpoints
 
 # These are separated, as some other services may need different handling for topics and endpoints.
-api.add_resource(PublishMessage, "/publish/topic/<target_id>", endpoint="publish_to_topic")
-api.add_resource(PublishMessage, "/publish/endpoint/<target_id>", endpoint="publish_to_endpoint")
+api.add_resource(PublishMessage, PATH_PREFIX + "/publish/topic/<target_id>", endpoint="publish_to_topic")
+api.add_resource(PublishMessage, PATH_PREFIX + "/publish/endpoint/<target_id>", endpoint="publish_to_endpoint")
 
-api.add_resource(Topic, "/topic/<topic_id>")
+api.add_resource(Topic, PATH_PREFIX + "/topic/<topic_id>")
 
 
 def main():  # pylint:disable=missing-docstring

--- a/push_service/app.py
+++ b/push_service/app.py
@@ -80,6 +80,14 @@ AWS_SECRET_KEY = os.environ["AWS_SECRET_KEY"]
 AWS_ACCESS_KEY = os.environ["AWS_ACCESS_KEY"]
 AWS_REGION = os.environ["AWS_REGION"]
 AUTOSUBSCRIBE_TOPICS = [topic for topic in os.environ.get("AUTOSUBSCRIBE_TOPICS", "").split(",") if len(topic)]
+
+# Check for path prefix
+if os.environ.get("PATH_PREFIX"):
+    PATH_PREFIX = "/" + os.environ.get('PATH_PREFIX').strip("/")
+    logger.debug("PATH_PREFIX set to '%s'", PATH_PREFIX)
+else:
+    PATH_PREFIX = ""
+
 PLATFORM_RE = re.compile("(?P<platform_identifier>[A-Z_]{1,50})_PLATFORM_APPLICATION")
 CONFIG = get_application_config(os.environ)
 BOTO_ERRORS = [
@@ -114,7 +122,7 @@ def decode_base64_id(encoded_string):
 
 
 app = Flask("push-service")  # pylint:disable=invalid-name
-api = Api(app)  # pylint:disable=invalid-name
+api = Api(app, prefix=PATH_PREFIX)  # pylint:disable=invalid-name
 app.before_request(check_authorization)
 
 sns = boto3.client("sns", region_name=AWS_REGION, aws_access_key_id=AWS_ACCESS_KEY, aws_secret_access_key=AWS_SECRET_KEY)  # pylint:disable=invalid-name
@@ -323,28 +331,21 @@ class PublishMessage(Resource):
         target_id = decode_base64_id(target_id)
         return publish(data, target_id)
 
-# Check for path prefix
-if os.environ.get('PATH_PREFIX'):
-    PATH_PREFIX = "/" + os.environ.get('PATH_PREFIX')
-    logger.info("PATH_PREFIX set to '%s'", PATH_PREFIX)
-else:
-    PATH_PREFIX = ""
+api.add_resource(Device, "/device")
+api.add_resource(DeviceDetails, "/device/<endpoint_id>")
+api.add_resource(Topics, "/topics")  # POST is admin-only operation.
+api.add_resource(Subscription, "/subscription/topic/<topic_id>/target/<target_id>")
 
-api.add_resource(Device, PATH_PREFIX + "/device")
-api.add_resource(DeviceDetails, PATH_PREFIX + "/device/<endpoint_id>")
-api.add_resource(Topics, PATH_PREFIX + "/topics")  # POST is admin-only operation.
-api.add_resource(Subscription, PATH_PREFIX + "/subscription/topic/<topic_id>/target/<target_id>")
-
-api.add_resource(Status, PATH_PREFIX + "/status")
-api.add_resource(UrlList, PATH_PREFIX + "/", resource_class_kwargs={"api": api})
+api.add_resource(Status, "/status")
+api.add_resource(UrlList, "/", resource_class_kwargs={"api": api})
 
 # admin endpoints
 
 # These are separated, as some other services may need different handling for topics and endpoints.
-api.add_resource(PublishMessage, PATH_PREFIX + "/publish/topic/<target_id>", endpoint="publish_to_topic")
-api.add_resource(PublishMessage, PATH_PREFIX + "/publish/endpoint/<target_id>", endpoint="publish_to_endpoint")
+api.add_resource(PublishMessage, "/publish/topic/<target_id>", endpoint="publish_to_topic")
+api.add_resource(PublishMessage, "/publish/endpoint/<target_id>", endpoint="publish_to_endpoint")
 
-api.add_resource(Topic, PATH_PREFIX + "/topic/<topic_id>")
+api.add_resource(Topic, "/topic/<topic_id>")
 
 
 def main():  # pylint:disable=missing-docstring


### PR DESCRIPTION
Adds support for an optional prefix added to the URL path (without the leading '/'). eg. with a value of 'push-service' the 'topics' endpoint would be under '/push-service/topics'
attn @ojarva 
